### PR TITLE
Contributorのリスト画面のレイアウト修正

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -65,6 +65,10 @@ dependencies {
     //coroutine
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.5.0'
 
+    //glide
+    implementation 'com.github.bumptech.glide:glide:4.12.0'
+    annotationProcessor 'com.github.bumptech.glide:compiler:4.12.0'
+
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'

--- a/app/src/main/java/com/example/contributorsapp/ui/listContributors/ListContributorsFragment.kt
+++ b/app/src/main/java/com/example/contributorsapp/ui/listContributors/ListContributorsFragment.kt
@@ -7,6 +7,7 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.lifecycle.Observer
 import androidx.navigation.fragment.findNavController
+import androidx.recyclerview.widget.DividerItemDecoration
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.example.contributorsapp.R
 import com.example.contributorsapp.databinding.FragmentListContributorsBinding
@@ -25,11 +26,14 @@ class ListContributorsFragment : Fragment() {
 
         listContributorsViewModel.fetchContributorsList()
 
+        val dividerItemDecoration = DividerItemDecoration(context, LinearLayoutManager(context).orientation)
+        binding.lvContributor.addItemDecoration(dividerItemDecoration)
         val layout = LinearLayoutManager(context)
         binding.lvContributor.layoutManager = layout
         binding.viewModel = listContributorsViewModel
         adapter = RecyclerAdapter(listContributorsViewModel.contributorsList.value?: listOf())
         binding.lvContributor.adapter = adapter
+
 
         listContributorsViewModel.contributorsList.observe(viewLifecycleOwner, Observer {
             adapter = binding.lvContributor.adapter as RecyclerAdapter
@@ -56,10 +60,6 @@ class ListContributorsFragment : Fragment() {
                 }
             }
         )
-
-
-
     }
-
 }
 

--- a/app/src/main/java/com/example/contributorsapp/ui/listContributors/ListContributorsFragment.kt
+++ b/app/src/main/java/com/example/contributorsapp/ui/listContributors/ListContributorsFragment.kt
@@ -9,7 +9,6 @@ import androidx.lifecycle.Observer
 import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.DividerItemDecoration
 import androidx.recyclerview.widget.LinearLayoutManager
-import com.example.contributorsapp.R
 import com.example.contributorsapp.databinding.FragmentListContributorsBinding
 import com.example.contributorsapp.model.ContributorsData
 
@@ -19,35 +18,36 @@ class ListContributorsFragment : Fragment() {
     //private val listContributorsViewModel = this.context?.let { ListContributorsViewModel(it) }
     private val listContributorsViewModel = ListContributorsViewModel()
 
-    private lateinit var adapter: RecyclerAdapter
-
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         binding = FragmentListContributorsBinding.inflate(inflater, container, false)
 
         listContributorsViewModel.fetchContributorsList()
-
-        val dividerItemDecoration = DividerItemDecoration(context, LinearLayoutManager(context).orientation)
-        binding.lvContributor.addItemDecoration(dividerItemDecoration)
-        val layout = LinearLayoutManager(context)
-        binding.lvContributor.layoutManager = layout
-        binding.viewModel = listContributorsViewModel
-        adapter = RecyclerAdapter(listContributorsViewModel.contributorsList.value?: listOf())
-        binding.lvContributor.adapter = adapter
-
-
-        listContributorsViewModel.contributorsList.observe(viewLifecycleOwner, Observer {
-            adapter = binding.lvContributor.adapter as RecyclerAdapter
-            adapter.setContributors(it)
-
-        })
-
+        showAdapter()
         return binding.root
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        adapter.setOnClickListener(
+        showAdapter()
+    }
+
+    private fun showAdapter(){
+        val dividerItemDecoration = DividerItemDecoration(context, LinearLayoutManager(context).orientation)
+        binding.lvContributor.addItemDecoration(dividerItemDecoration)
+        val layout = LinearLayoutManager(context)
+        binding.lvContributor.layoutManager = layout
+        binding.viewModel = listContributorsViewModel
+        var adapter = activity?.let{RecyclerAdapter(it,listContributorsViewModel.contributorsList.value?: listOf())}
+        binding.lvContributor.adapter = adapter
+
+        listContributorsViewModel.contributorsList.observe(viewLifecycleOwner, Observer {
+            adapter = binding.lvContributor.adapter as RecyclerAdapter
+            adapter?.setContributors(it)
+
+        })
+
+        adapter?.setOnClickListener(
             object: RecyclerAdapter.OnItemClickListener{
                 override fun onItemClickListener(
                     view: View,
@@ -60,6 +60,8 @@ class ListContributorsFragment : Fragment() {
                 }
             }
         )
+
+
     }
 }
 

--- a/app/src/main/java/com/example/contributorsapp/ui/listContributors/RecyclerAdapter.kt
+++ b/app/src/main/java/com/example/contributorsapp/ui/listContributors/RecyclerAdapter.kt
@@ -1,15 +1,18 @@
 package com.example.contributorsapp.ui.listContributors
 
+import android.content.Context
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.databinding.DataBindingUtil
 import androidx.recyclerview.widget.RecyclerView
+import com.bumptech.glide.Glide
+import com.bumptech.glide.load.resource.drawable.DrawableTransitionOptions
 import com.example.contributorsapp.R
 import com.example.contributorsapp.databinding.ListContributorBinding
 import com.example.contributorsapp.model.ContributorsData
 
-class RecyclerAdapter(private var data: List<ContributorsData>): RecyclerView.Adapter<RecyclerAdapter.RecyclerViewHolder>() {
+class RecyclerAdapter(val context: Context, private var data: List<ContributorsData>): RecyclerView.Adapter<RecyclerAdapter.RecyclerViewHolder>() {
 
     class RecyclerViewHolder(val binding: ListContributorBinding): RecyclerView.ViewHolder(binding.root)
 
@@ -34,6 +37,12 @@ class RecyclerAdapter(private var data: List<ContributorsData>): RecyclerView.Ad
     override fun onBindViewHolder(holder: RecyclerViewHolder, position: Int) {
         val contributor = data[position]
         holder.binding.viewModel = ContributorsData(contributor.id, contributor.login, contributor.contributions, contributor.avatar_url)
+
+        Glide.with(context)
+            .load(contributor.avatar_url)
+            .circleCrop()
+            .transition(DrawableTransitionOptions.withCrossFade()) // default is 300
+            .into(holder.binding.ivIcon)
 
         holder.binding.layoutList.setOnClickListener {
             listener.onItemClickListener(it, position, contributor)

--- a/app/src/main/res/layout/list_contributor.xml
+++ b/app/src/main/res/layout/list_contributor.xml
@@ -15,15 +15,27 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content">
 
+        <ImageView
+            android:id="@+id/ivIcon"
+            android:layout_width="56dp"
+            android:layout_height="56dp"
+            android:layout_marginStart="16dp"
+            android:layout_marginTop="16dp"
+            android:layout_marginBottom="16dp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
         <TextView
             android:id="@+id/tvLogin"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="@{viewModel.component2()}"
             android:layout_marginStart="16dp"
-            android:layout_marginTop="16dp"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
+            android:text="@{viewModel.component2()}"
+            android:textSize="20sp"
+            android:textStyle="bold"
+            app:layout_constraintStart_toEndOf="@+id/ivIcon"
+            app:layout_constraintTop_toTopOf="@+id/ivIcon" />
 
         <TextView
             android:id="@+id/tvConNum"
@@ -31,20 +43,19 @@
             android:layout_height="wrap_content"
             android:layout_marginStart="8dp"
             android:text="@{Integer.toString(viewModel.component3())}"
+            android:textSize="16sp"
+            android:textStyle="bold"
             app:layout_constraintBottom_toBottomOf="@+id/tvConItem"
-            app:layout_constraintStart_toEndOf="@+id/tvConItem"
-            app:layout_constraintTop_toTopOf="@+id/tvConItem" />
+            app:layout_constraintStart_toEndOf="@+id/tvConItem" />
 
         <TextView
             android:id="@+id/tvConItem"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
+            android:layout_marginStart="16dp"
             android:text="@string/tv_contribution_item_name"
-            android:layout_marginStart="24dp"
-            android:layout_marginTop="16dp"
-            android:layout_marginBottom="16dp"
             app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintStart_toEndOf="@+id/ivIcon"
             app:layout_constraintTop_toBottomOf="@+id/tvLogin" />
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>


### PR DESCRIPTION
## 対応するissue
- close #4 

## 概要
- Contributorのリスト画面のレイアウト修正

## 意図する動作内容（または変更点）
- Contributorのアイコンを表示するようにした
- Login（UserId）の大きさを大きくするなど，テキストサイズ・スタイルの変更を行った（詳細は写真へ）
- 項目間に区切りの線の追加

## スクリーンショット（UI作成，変更時）
<img src="https://user-images.githubusercontent.com/38235279/127755662-d7b6b455-8986-41c3-b7c0-8b569b7b12a9.png" width="300" />

## その他（感想）
レイアウトの変更具合見ると別物感あるから，やっぱりデザインって大事
画像をURLから引っ張ってくるの初めてで楽しかった