### PR TITLE
ユーザ詳細画面のレイアウト修正

### DIFF
--- a/app/src/main/java/com/example/contributorsapp/model/DetailData.kt
+++ b/app/src/main/java/com/example/contributorsapp/model/DetailData.kt
@@ -7,5 +7,7 @@ data class DetailData(
     val avatar_url: String,
     val html_url: String,
     val followers: Int,
-    val following: Int
+    val following: Int,
+    val public_repos: Int,
+    val repos_url: String
 )

--- a/app/src/main/java/com/example/contributorsapp/model/Repository.kt
+++ b/app/src/main/java/com/example/contributorsapp/model/Repository.kt
@@ -38,7 +38,7 @@ class Repository() {
     }
 
     suspend fun fetchUserDetail(login: String): DetailData{
-        var detail = DetailData(0, "null", "null", "null", "null", 0, 0)
+        var detail = DetailData(0, "null", "null", "null", "null", 0, 0, 0, "")
 
         withContext(IO){
             try{

--- a/app/src/main/java/com/example/contributorsapp/ui/detailContributors/DetailContributorsFragment.kt
+++ b/app/src/main/java/com/example/contributorsapp/ui/detailContributors/DetailContributorsFragment.kt
@@ -20,7 +20,7 @@ class DetailContributorsFragment : Fragment() {
     private val args: DetailContributorsFragmentArgs by navArgs()
     private lateinit var intent: Intent
 
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         binding = FragmentDetailContributorsBinding.inflate(inflater, container, false)
 
         binding.lifecycleOwner = this

--- a/app/src/main/java/com/example/contributorsapp/ui/detailContributors/DetailContributorsFragment.kt
+++ b/app/src/main/java/com/example/contributorsapp/ui/detailContributors/DetailContributorsFragment.kt
@@ -1,5 +1,7 @@
 package com.example.contributorsapp.ui.detailContributors
 
+import android.content.Intent
+import android.net.Uri
 import android.os.Bundle
 import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
@@ -16,6 +18,7 @@ class DetailContributorsFragment : Fragment() {
     private lateinit var binding: FragmentDetailContributorsBinding
     private val detailContributorsViewModel = DetailContributorsViewModel()
     private val args: DetailContributorsFragmentArgs by navArgs()
+    private lateinit var intent: Intent
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         binding = FragmentDetailContributorsBinding.inflate(inflater, container, false)
@@ -34,10 +37,23 @@ class DetailContributorsFragment : Fragment() {
                     .transition(DrawableTransitionOptions.withCrossFade()) // default is 300
                     .into(binding.ivIcon)
             }
+
+            val uri = Uri.parse(newDetail.html_url)
+            intent = Intent(Intent.ACTION_VIEW,uri)
+
         }
 
         detailContributorsViewModel.detail.observe(viewLifecycleOwner,detailObserver)
 
         return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        binding.btBrowser.setOnClickListener{
+            startActivity(intent)
+        }
+
     }
 }

--- a/app/src/main/java/com/example/contributorsapp/ui/detailContributors/DetailContributorsFragment.kt
+++ b/app/src/main/java/com/example/contributorsapp/ui/detailContributors/DetailContributorsFragment.kt
@@ -5,8 +5,12 @@ import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.lifecycle.Observer
 import androidx.navigation.fragment.navArgs
+import com.bumptech.glide.Glide
+import com.bumptech.glide.load.resource.drawable.DrawableTransitionOptions
 import com.example.contributorsapp.databinding.FragmentDetailContributorsBinding
+import com.example.contributorsapp.model.DetailData
 
 class DetailContributorsFragment : Fragment() {
     private lateinit var binding: FragmentDetailContributorsBinding
@@ -21,6 +25,18 @@ class DetailContributorsFragment : Fragment() {
 
         detailContributorsViewModel.setLogin(args.login)
         detailContributorsViewModel.fetchDetail()
+
+        val detailObserver = Observer<DetailData>{ newDetail ->
+            context?.let{
+                Glide.with(it)
+                    .load(newDetail.avatar_url)
+                    .circleCrop()
+                    .transition(DrawableTransitionOptions.withCrossFade()) // default is 300
+                    .into(binding.ivIcon)
+            }
+        }
+
+        detailContributorsViewModel.detail.observe(viewLifecycleOwner,detailObserver)
 
         return binding.root
     }

--- a/app/src/main/java/com/example/contributorsapp/ui/detailContributors/DetailContributorsViewModel.kt
+++ b/app/src/main/java/com/example/contributorsapp/ui/detailContributors/DetailContributorsViewModel.kt
@@ -9,7 +9,7 @@ import com.example.contributorsapp.model.Repository
 import kotlinx.coroutines.launch
 
 class DetailContributorsViewModel: ViewModel() {
-    var detail: MutableLiveData<DetailData> = MutableLiveData(DetailData(0, "null", "null", "null", "null", 0, 0))
+    var detail: MutableLiveData<DetailData> = MutableLiveData(DetailData(0, "null", "null", "null", "null", 0, 0,0,""))
     private val repository = Repository()
     private var login = ""
 

--- a/app/src/main/res/layout/fragment_detail_contributors.xml
+++ b/app/src/main/res/layout/fragment_detail_contributors.xml
@@ -16,25 +16,35 @@
         android:layout_height="match_parent"
         tools:context=".ui.detailContributors.DetailContributorsFragment">
 
-
-        <TextView
-            android:id="@+id/tvName"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:text="@{viewModel.detail.component2()}"
+        <ImageView
+            android:id="@+id/ivIcon"
+            android:layout_width="104dp"
+            android:layout_height="104dp"
             android:layout_marginStart="16dp"
             android:layout_marginTop="16dp"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
 
         <TextView
+            android:id="@+id/tvName"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="16dp"
+            android:text="@{viewModel.detail.component2()}"
+            android:textSize="24sp"
+            android:textStyle="bold"
+            app:layout_constraintStart_toEndOf="@+id/ivIcon"
+            app:layout_constraintTop_toTopOf="@+id/ivIcon" />
+
+        <TextView
             android:id="@+id/tvLogin"
-            android:layout_width="match_parent"
+            android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginStart="16dp"
             android:layout_marginTop="8dp"
             android:text="@{viewModel.detail.component3()}"
-            app:layout_constraintStart_toStartOf="parent"
+            android:textSize="20sp"
+            app:layout_constraintStart_toEndOf="@+id/ivIcon"
             app:layout_constraintTop_toBottomOf="@+id/tvName" />
 
 
@@ -42,11 +52,10 @@
             android:id="@+id/tvFollowerItem"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginStart="16dp"
-            android:layout_marginTop="16dp"
+            android:layout_marginStart="24dp"
             android:text="@string/tv_followers_item_name"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/tvLogin" />
+            app:layout_constraintStart_toEndOf="@+id/tvRepoNum"
+            app:layout_constraintTop_toTopOf="@+id/tvRepoItem" />
 
         <TextView
             android:id="@+id/tvFollowerNum"
@@ -54,19 +63,18 @@
             android:layout_height="wrap_content"
             android:layout_marginStart="8dp"
             android:text="@{Integer.toString(viewModel.detail.component6())}"
+            android:textSize="16sp"
             app:layout_constraintBottom_toBottomOf="@+id/tvFollowerItem"
-            app:layout_constraintStart_toEndOf="@+id/tvFollowerItem"
-            app:layout_constraintTop_toTopOf="@+id/tvFollowerItem" />
+            app:layout_constraintStart_toEndOf="@+id/tvFollowerItem" />
 
         <TextView
             android:id="@+id/tvFollowingItem"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginStart="16dp"
-            android:layout_marginTop="8dp"
+            android:layout_marginStart="24dp"
             android:text="@string/tv_following_item_name"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/tvFollowerItem" />
+            app:layout_constraintStart_toEndOf="@+id/tvFollowerNum"
+            app:layout_constraintTop_toTopOf="@+id/tvFollowerItem" />
 
         <TextView
             android:id="@+id/tvFollowingNum"
@@ -74,8 +82,29 @@
             android:layout_height="wrap_content"
             android:layout_marginStart="8dp"
             android:text="@{Integer.toString(viewModel.detail.component7())}"
+            android:textSize="16sp"
             app:layout_constraintBottom_toBottomOf="@+id/tvFollowingItem"
-            app:layout_constraintStart_toEndOf="@+id/tvFollowingItem"
-            app:layout_constraintTop_toTopOf="@+id/tvFollowingItem" />
+            app:layout_constraintStart_toEndOf="@+id/tvFollowingItem" />
+
+        <TextView
+            android:id="@+id/tvRepoItem"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="16dp"
+            android:layout_marginTop="16dp"
+            android:text="@string/tv_public_repo_item_name"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/ivIcon" />
+
+        <TextView
+            android:id="@+id/tvRepoNum"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="8dp"
+            android:text="@{Integer.toString(viewModel.detail.component8())}"
+
+            android:textSize="16sp"
+            app:layout_constraintBottom_toBottomOf="@+id/tvRepoItem"
+            app:layout_constraintStart_toEndOf="@+id/tvRepoItem" />
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/app/src/main/res/layout/fragment_detail_contributors.xml
+++ b/app/src/main/res/layout/fragment_detail_contributors.xml
@@ -106,5 +106,18 @@
             android:textSize="16sp"
             app:layout_constraintBottom_toBottomOf="@+id/tvRepoItem"
             app:layout_constraintStart_toEndOf="@+id/tvRepoItem" />
+
+        <Button
+            android:id="@+id/btBrowser"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="16dp"
+            android:layout_marginTop="16dp"
+            android:layout_marginEnd="16dp"
+            android:text="@string/bt_browser_access"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/tvRepoItem" />
+
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,8 +1,8 @@
 <resources>
     <string name="app_name">Contributors App</string>
     <string name="tv_contribution_item_name">contributions:</string>
-    <string name="tv_followers_item_name">followers:</string>
-    <string name="tv_following_item_name">following:</string>
+    <string name="tv_followers_item_name">Followers:</string>
+    <string name="tv_following_item_name">Following:</string>
     <string name="tv_public_repo_item_name">Repositories:</string>
     <string name="bt_browser_access">ブラウザで開く</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,6 +1,7 @@
 <resources>
     <string name="app_name">Contributors App</string>
     <string name="tv_contribution_item_name">contributions:</string>
-    <string name="tv_followers_item_name">followers</string>
+    <string name="tv_followers_item_name">followers:</string>
     <string name="tv_following_item_name">following:</string>
+    <string name="tv_public_repo_item_name">Repositories:</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -4,4 +4,5 @@
     <string name="tv_followers_item_name">followers:</string>
     <string name="tv_following_item_name">following:</string>
     <string name="tv_public_repo_item_name">Repositories:</string>
+    <string name="bt_browser_access">ブラウザで開く</string>
 </resources>


### PR DESCRIPTION
## 対応するissue
- なし

## 概要
- ユーザ詳細画面のレイアウト修正

## 意図する動作内容（または変更点）
- アイコンの追加
- テキストサイズなどの変更
- リポジトリ数の表示
- ブラウザで開くボタンの追加
など

## スクリーンショット（UI作成，変更時）
<img src="https://user-images.githubusercontent.com/38235279/127761345-f605176e-7564-4fdc-bc5d-65a001eadf6b.png" width="300" />

## その他
下にリポジトリのリスト追加したい～～～＾