### PR TITLE
fix:クリックイベント処理の変更

### DIFF
--- a/app/src/main/java/com/example/contributorsapp/ui/detailContributors/DetailContributorsFragment.kt
+++ b/app/src/main/java/com/example/contributorsapp/ui/detailContributors/DetailContributorsFragment.kt
@@ -20,11 +20,17 @@ class DetailContributorsFragment : Fragment() {
     private val args: DetailContributorsFragmentArgs by navArgs()
     private lateinit var intent: Intent
 
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
         binding = FragmentDetailContributorsBinding.inflate(inflater, container, false)
 
-        binding.lifecycleOwner = this
-        binding.viewModel = detailContributorsViewModel
+        binding.let {
+            it.lifecycleOwner = viewLifecycleOwner
+            it.viewModel = detailContributorsViewModel
+        }
 
         detailContributorsViewModel.setLogin(args.login)
         detailContributorsViewModel.fetchDetail()
@@ -47,6 +53,7 @@ class DetailContributorsFragment : Fragment() {
 
         return binding.root
     }
+
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)

--- a/app/src/main/java/com/example/contributorsapp/ui/listContributors/ContributorListAdapter.kt
+++ b/app/src/main/java/com/example/contributorsapp/ui/listContributors/ContributorListAdapter.kt
@@ -12,9 +12,11 @@ import com.example.contributorsapp.R
 import com.example.contributorsapp.databinding.ListContributorBinding
 import com.example.contributorsapp.model.ContributorData
 
-class ContributorListAdapter(val context: Context, private var data: List<ContributorData>) : RecyclerView.Adapter<ContributorListAdapter.RecyclerViewHolder>() {
+class ContributorListAdapter(private var data: List<ContributorData>) :
+    RecyclerView.Adapter<ContributorListAdapter.RecyclerViewHolder>() {
 
-    class RecyclerViewHolder(val binding: ListContributorBinding) : RecyclerView.ViewHolder(binding.root)
+    class RecyclerViewHolder(val binding: ListContributorBinding) :
+        RecyclerView.ViewHolder(binding.root)
 
     private lateinit var listener: OnItemClickListener
 
@@ -43,7 +45,7 @@ class ContributorListAdapter(val context: Context, private var data: List<Contri
             contributor.avatar_url
         )
 
-        Glide.with(context)
+        Glide.with(holder.itemView.context)
             .load(contributor.avatar_url)
             .circleCrop()
             .transition(DrawableTransitionOptions.withCrossFade()) // default is 300

--- a/app/src/main/java/com/example/contributorsapp/ui/listContributors/ListContributorsFragment.kt
+++ b/app/src/main/java/com/example/contributorsapp/ui/listContributors/ListContributorsFragment.kt
@@ -15,11 +15,16 @@ import com.example.contributorsapp.model.ContributorData
 
 class ListContributorsFragment : Fragment() {
     private lateinit var binding: FragmentListContributorsBinding
+    private var adapter = ContributorListAdapter(listOf())
 
     //private val listContributorsViewModel = this.context?.let { ListContributorsViewModel(it) }
     private val listContributorsViewModel = ListContributorsViewModel()
 
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
         binding = FragmentListContributorsBinding.inflate(inflater, container, false)
 
         listContributorsViewModel.fetchContributorsList()
@@ -30,38 +35,15 @@ class ListContributorsFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        showAdapter()
-    }
-
-    private fun showAdapter() {
-        val dividerItemDecoration =
-            DividerItemDecoration(context, LinearLayoutManager(context).orientation)
-        binding.lvContributor.addItemDecoration(dividerItemDecoration)
-        val layout = LinearLayoutManager(context)
-        binding.lvContributor.layoutManager = layout
-        binding.viewModel = listContributorsViewModel
-        var adapter = activity?.let {
-            ContributorListAdapter(
-                it,
-                listContributorsViewModel.contributorsList.value ?: listOf()
-            )
-        }
-        binding.lvContributor.adapter = adapter
-
-        listContributorsViewModel.contributorsList.observe(viewLifecycleOwner, Observer {
-            adapter = binding.lvContributor.adapter as ContributorListAdapter
-            adapter?.setContributors(it)
-
-        })
-
-        adapter?.setOnClickListener(
+        adapter.setOnClickListener(
             object : ContributorListAdapter.OnItemClickListener {
                 override fun onItemClickListener(
                     view: View,
                     position: Int,
                     clickedContributor: ContributorData
                 ) {
-                    val login = listContributorsViewModel.contributorsList.value?.get(position)?.login ?: ""
+                    val login =
+                        listContributorsViewModel.contributorsList.value?.get(position)?.login ?: ""
                     val action = ListContributorsFragmentDirections.actionListToDetail(login)
                     findNavController().navigate(action)
 
@@ -69,7 +51,27 @@ class ListContributorsFragment : Fragment() {
             }
         )
 
+    }
 
+    private fun showAdapter() {
+        val dividerItemDecoration =
+            DividerItemDecoration(context, LinearLayoutManager(context).orientation)
+        val layout = LinearLayoutManager(context)
+
+        binding.let {
+            it.lvContributor.addItemDecoration(dividerItemDecoration)
+            it.lvContributor.layoutManager = layout
+            it.viewModel = listContributorsViewModel
+            adapter =
+                ContributorListAdapter(listContributorsViewModel.contributorsList.value ?: listOf())
+            it.lvContributor.adapter = adapter
+        }
+
+        listContributorsViewModel.contributorsList.observe(viewLifecycleOwner, Observer {
+            //adapter = binding.lvContributor.adapter as ContributorListAdapter
+            adapter.setContributors(it)
+
+        })
     }
 }
 


### PR DESCRIPTION
## 対応するissue
- close #{issue番号}

## 概要
- adapter参照をonCreateViewのみにした

## 意図する動作内容（または変更点）
- 動作に特定の変更はない
- adapter参照をonCreateViewのみにした
- また，一部bindingの部分の処理をまとめて書いた
- 
## スクリーンショット（UI作成，変更時）
<img src="" width="300" />

## その他
もしかしてRecyclerView使う時ListAdapterにしたほうが書きやすいor見やすいとかある？？？((あとで変更するかも
